### PR TITLE
Proto/api mapping

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     GRADLE_OPTS: -Xmx768m -Xms512m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError
 test:
   override:
-  - emulator -avd circleci-android22 -no-audio -no-boot-anim -no-window:
+  - emulator -avd circleci-android22 -no-audio -no-window:
           background: true
           parallel: true
   - circle-android wait-for-boot

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ test:
             background: true
             parallel: true
     - circle-android wait-for-boot:
+            parallel: true
   override:
     - ./gradlew clean checkDebug -PdisablePreDex
     - ./gradlew test connectedCheck -PdisablePreDex

--- a/circle.yml
+++ b/circle.yml
@@ -3,13 +3,14 @@ machine:
     DEFAULT_JVM_OPTS: -Xms512m -Xmx768m
     GRADLE_OPTS: -Xmx768m -Xms512m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError
 test:
+  pre:
+    - emulator -avd circleci-android22 -no-audio -no-window:
+            background: true
+            parallel: true
+    - circle-android wait-for-boot
   override:
-  - emulator -avd circleci-android22 -no-audio -no-window:
-          background: true
-          parallel: true
-  - circle-android wait-for-boot
-  - ./gradlew clean checkDebug -PdisablePreDex
-  - ./gradlew test connectedCheck -PdisablePreDex
-  - cp -r cache/build/outputs/androidTest-results/connected $CIRCLE_TEST_REPORTS
-  - cp -r conductor/build/test-results/ $CIRCLE_TEST_REPORTS
-  - cp -r remote/build/test-results/ $CIRCLE_TEST_REPORTS
+    - ./gradlew clean checkDebug -PdisablePreDex
+    - ./gradlew test connectedCheck -PdisablePreDex
+    - cp -r cache/build/outputs/androidTest-results/connected $CIRCLE_TEST_REPORTS
+    - cp -r conductor/build/test-results/ $CIRCLE_TEST_REPORTS
+    - cp -r remote/build/test-results/ $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  environment:
+    DEFAULT_JVM_OPTS: -Xms512m -Xmx768m
+    GRADLE_OPTS: -Xmx768m -Xms512m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError
+test:
+  override:
+  - emulator -avd circleci-android22 -no-audio -no-boot-anim -no-window:
+          background: true
+          parallel: true
+  - circle-android wait-for-boot:
+          parallel: true
+  - ./gradlew clean checkDebug -PdisablePreDex
+  - ./gradlew test connectedCheck -PdisablePreDex
+  - cp -r cache/build/outputs/androidTest-results/connected $CIRCLE_TEST_REPORTS
+  - cp -r conductor/build/test-results/ $CIRCLE_TEST_REPORTS
+  - cp -r core/build/test-results/ $CIRCLE_TEST_REPORTS
+  - cp -r model/build/test-results/ $CIRCLE_TEST_REPORTS
+  - cp -r presentation/build/test-results/ $CIRCLE_TEST_REPORTS
+  - cp -r remote/build/test-results/ $CIRCLE_TEST_REPORTS
+  - cp -r remoteentity/build/test-results/ $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -3,13 +3,11 @@ machine:
     DEFAULT_JVM_OPTS: -Xms512m -Xmx768m
     GRADLE_OPTS: -Xmx768m -Xms512m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError
 test:
-  pre:
-    - emulator -avd circleci-android21 -no-audio -no-boot-anim -no-window:
+  override:
+    - emulator -avd circleci-android22 -no-audio -no-window:
             background: true
             parallel: true
-    - circle-android wait-for-boot:
-            parallel: true
-  override:
+    - circle-android wait-for-boot
     - ./gradlew clean checkDebug -PdisablePreDex
     - ./gradlew test connectedCheck -PdisablePreDex
     - cp -r cache/build/outputs/androidTest-results/connected $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ test:
     - emulator -avd circleci-android21 -no-audio -no-boot-anim -no-window:
             background: true
             parallel: true
-    - circle-android wait-for-boot
+    - circle-android wait-for-boot:
   override:
     - ./gradlew clean checkDebug -PdisablePreDex
     - ./gradlew test connectedCheck -PdisablePreDex

--- a/circle.yml
+++ b/circle.yml
@@ -7,14 +7,9 @@ test:
   - emulator -avd circleci-android22 -no-audio -no-boot-anim -no-window:
           background: true
           parallel: true
-  - circle-android wait-for-boot:
-          parallel: true
+  - circle-android wait-for-boot
   - ./gradlew clean checkDebug -PdisablePreDex
   - ./gradlew test connectedCheck -PdisablePreDex
   - cp -r cache/build/outputs/androidTest-results/connected $CIRCLE_TEST_REPORTS
   - cp -r conductor/build/test-results/ $CIRCLE_TEST_REPORTS
-  - cp -r core/build/test-results/ $CIRCLE_TEST_REPORTS
-  - cp -r model/build/test-results/ $CIRCLE_TEST_REPORTS
-  - cp -r presentation/build/test-results/ $CIRCLE_TEST_REPORTS
   - cp -r remote/build/test-results/ $CIRCLE_TEST_REPORTS
-  - cp -r remoteentity/build/test-results/ $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     GRADLE_OPTS: -Xmx768m -Xms512m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError
 test:
   pre:
-    - emulator -avd circleci-android22 -no-audio -no-window:
+    - emulator -avd circleci-android21 -no-audio -no-boot-anim -no-window:
             background: true
             parallel: true
     - circle-android wait-for-boot

--- a/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactory.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactory.java
@@ -5,5 +5,5 @@ package com.philheenan.immaterial.remote;
  */
 public interface ModelFactory<A, M> {
 
-    M fromApiEntity(A entity);
+    M fromEntity(A entity);
 }

--- a/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactory.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactory.java
@@ -1,0 +1,9 @@
+package com.philheenan.immaterial.remote;
+
+/**
+ * @author Phil Heenan on 28/08/15.
+ */
+public interface ModelFactory<A, M> {
+
+    M fromApiEntity(A entity);
+}

--- a/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactoryModule.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/ModelFactoryModule.java
@@ -1,0 +1,23 @@
+package com.philheenan.immaterial.remote;
+
+import com.philheenan.immaterial.remote.entity.SampleEntity;
+import com.philheenan.immaterial.remote.sample.SampleModelFactory;
+import com.philheenan.immaterial.sample.Sample;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * @author Phil Heenan on 28/08/15.
+ */
+@Module(
+        complete = false,
+        library = true
+)
+public class ModelFactoryModule {
+
+    @Provides
+    ModelFactory<SampleEntity, Sample> provideSampleModelFactory() {
+        return new SampleModelFactory();
+    }
+}

--- a/remote/src/main/java/com/philheenan/immaterial/remote/RemoteModule.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/RemoteModule.java
@@ -12,7 +12,10 @@ import dagger.Provides;
  */
 @Module (
         complete = false,
-        library = true
+        library = true,
+        includes = {
+            ModelFactoryModule.class
+        }
 )
 public class RemoteModule {
 
@@ -20,4 +23,5 @@ public class RemoteModule {
     SampleRemoteFacet providesampleFacet() {
         return new SampleRemoteApiFacet();
     }
+
 }

--- a/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleModelFactory.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleModelFactory.java
@@ -1,0 +1,21 @@
+package com.philheenan.immaterial.remote.sample;
+
+import com.philheenan.immaterial.remote.ModelFactory;
+import com.philheenan.immaterial.remote.entity.SampleEntity;
+import com.philheenan.immaterial.sample.Sample;
+
+/**
+ * @author Phil Heenan on 28/08/15.
+ */
+public class SampleModelFactory implements ModelFactory<SampleEntity, Sample> {
+
+    @Override
+    public Sample fromApiEntity(SampleEntity entity) {
+        Sample sample = new Sample();
+        if (entity != null) {
+            sample.name = (entity.name != null && entity.name.length() > 0 ? entity.name + " " : "");
+            sample.name = sample.name + entity.version;
+        }
+        return sample;
+    }
+}

--- a/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleModelFactory.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleModelFactory.java
@@ -10,7 +10,7 @@ import com.philheenan.immaterial.sample.Sample;
 public class SampleModelFactory implements ModelFactory<SampleEntity, Sample> {
 
     @Override
-    public Sample fromApiEntity(SampleEntity entity) {
+    public Sample fromEntity(SampleEntity entity) {
         Sample sample = new Sample();
         if (entity != null) {
             sample.name = (entity.name != null && entity.name.length() > 0 ? entity.name + " " : "");

--- a/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleRemoteApiFacet.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleRemoteApiFacet.java
@@ -9,7 +9,6 @@ import com.philheenan.immaterial.sample.Sample;
 import javax.inject.Inject;
 
 import rx.Observable;
-import rx.Subscriber;
 import rx.functions.Func1;
 
 /**
@@ -29,7 +28,7 @@ public class SampleRemoteApiFacet implements SampleRemoteFacet {
         return new Func1<SampleEntity, Sample>() {
             @Override
             public Sample call(SampleEntity sampleEntity) {
-                return null;
+                return modelFactory.fromEntity(sampleEntity);
             }
         };
     }

--- a/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleRemoteApiFacet.java
+++ b/remote/src/main/java/com/philheenan/immaterial/remote/sample/SampleRemoteApiFacet.java
@@ -2,8 +2,11 @@ package com.philheenan.immaterial.remote.sample;
 
 import com.philheenan.immaterial.conductor.facets.sample.SampleRemoteFacet;
 import com.philheenan.immaterial.conductor.facets.sample.SampleRemoteRequest;
+import com.philheenan.immaterial.remote.ModelFactory;
 import com.philheenan.immaterial.remote.entity.SampleEntity;
 import com.philheenan.immaterial.sample.Sample;
+
+import javax.inject.Inject;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -13,6 +16,9 @@ import rx.functions.Func1;
  * @author Phil Heenan on 07/08/15.
  */
 public class SampleRemoteApiFacet implements SampleRemoteFacet {
+
+    @Inject
+    ModelFactory<SampleEntity, Sample> modelFactory;
 
     @Override
     public Observable<Sample> process(SampleRemoteRequest input) {

--- a/remote/src/test/java/com/philheenan/immaterial/remote/RemoteTestModule.java
+++ b/remote/src/test/java/com/philheenan/immaterial/remote/RemoteTestModule.java
@@ -1,5 +1,6 @@
 package com.philheenan.immaterial.remote;
 
+import com.philheenan.immaterial.remote.sample.SampleModelFactoryTest;
 import com.philheenan.immaterial.remote.sample.SampleRemoteFacetTest;
 
 import dagger.Module;
@@ -14,6 +15,7 @@ import dagger.Module;
         addsTo = RemoteModule.class,
         injects = {
                 RemoteBaseTest.class,
+                SampleModelFactoryTest.class,
                 SampleRemoteFacetTest.class
         }
 )

--- a/remote/src/test/java/com/philheenan/immaterial/remote/sample/SampleModelFactoryTest.java
+++ b/remote/src/test/java/com/philheenan/immaterial/remote/sample/SampleModelFactoryTest.java
@@ -1,0 +1,83 @@
+package com.philheenan.immaterial.remote.sample;
+
+import com.philheenan.immaterial.remote.ModelFactory;
+import com.philheenan.immaterial.remote.RemoteBaseTest;
+import com.philheenan.immaterial.remote.entity.SampleEntity;
+import com.philheenan.immaterial.sample.Sample;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Phil Heenan on 28/08/15.
+ */
+public class SampleModelFactoryTest extends RemoteBaseTest {
+
+    @Inject
+    ModelFactory<SampleEntity, Sample> modelFactory;
+
+    @Before
+    public void setup() {
+        super.setup();
+        graph.inject(this);
+    }
+
+    @Test
+    public void injectionTest() {
+        assertNotNull(modelFactory);
+    }
+
+    @Test
+    public void testModelMapping() {
+        SampleEntity entity = new SampleEntity();
+        entity.name = "Name";
+        entity.version = 10;
+        Sample sample = modelFactory.fromApiEntity(entity);
+        assertNotNull(sample);
+        assertEquals("Name 10", sample.name);
+    }
+
+    @Test
+    public void testNullEntityMapping() {
+        Sample sample = modelFactory.fromApiEntity(null);
+        assertNotNull(sample);
+        assertNull(sample.name);
+    }
+
+    @Test
+    public void testNullName() {
+        SampleEntity entity = new SampleEntity();
+        entity.name = null;
+        entity.version = 10;
+        Sample sample = modelFactory.fromApiEntity(entity);
+        assertNotNull(sample);
+        assertEquals("10", sample.name);
+    }
+
+    @Test
+    public void testNullVersion() {
+        SampleEntity entity = new SampleEntity();
+        entity.name = "Name";
+        Sample sample = modelFactory.fromApiEntity(entity);
+        assertNotNull(sample);
+        assertEquals("Name 0", sample.name);
+    }
+
+    @Test
+    public void testEmptyName() {
+        SampleEntity entity = new SampleEntity();
+        entity.name = "";
+        entity.version = 10;
+        Sample sample = modelFactory.fromApiEntity(entity);
+        assertNotNull(sample);
+        assertEquals("10", sample.name);
+    }
+
+
+}

--- a/remote/src/test/java/com/philheenan/immaterial/remote/sample/SampleModelFactoryTest.java
+++ b/remote/src/test/java/com/philheenan/immaterial/remote/sample/SampleModelFactoryTest.java
@@ -38,14 +38,14 @@ public class SampleModelFactoryTest extends RemoteBaseTest {
         SampleEntity entity = new SampleEntity();
         entity.name = "Name";
         entity.version = 10;
-        Sample sample = modelFactory.fromApiEntity(entity);
+        Sample sample = modelFactory.fromEntity(entity);
         assertNotNull(sample);
         assertEquals("Name 10", sample.name);
     }
 
     @Test
     public void testNullEntityMapping() {
-        Sample sample = modelFactory.fromApiEntity(null);
+        Sample sample = modelFactory.fromEntity(null);
         assertNotNull(sample);
         assertNull(sample.name);
     }
@@ -55,7 +55,7 @@ public class SampleModelFactoryTest extends RemoteBaseTest {
         SampleEntity entity = new SampleEntity();
         entity.name = null;
         entity.version = 10;
-        Sample sample = modelFactory.fromApiEntity(entity);
+        Sample sample = modelFactory.fromEntity(entity);
         assertNotNull(sample);
         assertEquals("10", sample.name);
     }
@@ -64,7 +64,7 @@ public class SampleModelFactoryTest extends RemoteBaseTest {
     public void testNullVersion() {
         SampleEntity entity = new SampleEntity();
         entity.name = "Name";
-        Sample sample = modelFactory.fromApiEntity(entity);
+        Sample sample = modelFactory.fromEntity(entity);
         assertNotNull(sample);
         assertEquals("Name 0", sample.name);
     }
@@ -74,7 +74,7 @@ public class SampleModelFactoryTest extends RemoteBaseTest {
         SampleEntity entity = new SampleEntity();
         entity.name = "";
         entity.version = 10;
-        Sample sample = modelFactory.fromApiEntity(entity);
+        Sample sample = modelFactory.fromEntity(entity);
         assertNotNull(sample);
         assertEquals("10", sample.name);
     }


### PR DESCRIPTION
Prototype function for mapping a simple entity object to an application domain model object. Implements a base `ModelFactory` interface using generics for typing the input `entity` and output `model` types. Functionality to perform the transform is handled through the `fromEntity(T entity)' method.
